### PR TITLE
[fix] correct PHP version is 7.0 minimum

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "~5.6|~7.0",
+        "php": "~7.0",
         "guzzlehttp/guzzle": "^6.3",
         "sabre/cache": "^1.0"
     },


### PR DESCRIPTION
It's stated the package works for PHP 5.6, however, in the code you use PHP 7.0+ functionality, for example:

- coalesce operators ??, such as
```php
$maxsize = $settings['cache_maxsize'] ?? self::CACHE_MAXSIZE;
```
- scalar types in function declarations, such as:
```php
public function set(string $name, $value)
```