### PR TITLE
[add] ext-json requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     "require": {
         "php": "~5.6|~7.0",
         "guzzlehttp/guzzle": "^6.3",
-        "sabre/cache": "^1.0"
+        "sabre/cache": "^1.0",
+        "ext-json": "*"
     },
     "require-dev": {
         "phpunit/phpunit" : ">=5.4.3",


### PR DESCRIPTION
You use `json_decode` function that requires a related dependency in composer.