### PR TITLE
[add] support for Guzzle7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "~7.0",
-        "guzzlehttp/guzzle": "^6.3",
+        "guzzlehttp/guzzle": "^6.3||^7.0",
         "sabre/cache": "^1.0",
         "ext-json": "*"
     },


### PR DESCRIPTION
This library required Guzzle 6.x only. And does not work with Guzzle7.
Fixes #15 