### PR TITLE
Init cache "element queue" before use.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+### 2.1.1 (January 12 2021)
+
+- Bug fix issue reported in Laravel SDK
+  (https://github.com/ipinfo/laravel/issues/14) which also applies in PHP SDK,
+  with https://github.com/ipinfo/php/pull/27.
+
 ### 2.1.0 (December 2 2020)
 
 - Deprecate PHP 7.2 support.

--- a/src/cache/DefaultCache.php
+++ b/src/cache/DefaultCache.php
@@ -17,7 +17,7 @@ class DefaultCache implements CacheInterface
     public function __construct(int $maxsize, int $ttl)
     {
         $this->cache = new \Sabre\Cache\Memory();
-        $this->element_queue;
+        $this->element_queue = array();
         $this->maxsize = $maxsize;
         $this->ttl = $ttl;
     }


### PR DESCRIPTION
Otherwise if the app is started while keys do exist, and the first key searched exists, there will be an error inside `manageSize`.