### PR TITLE
docs: Clarify installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,17 @@ The free plan is limited to 50,000 requests per month, and doesn't include some 
 
 #### Installation
 
-First download Composer by following the instructions [here](https://getcomposer.org/download/). After successful installation run the following command.
+The package works with PHP 8 and is available using [Composer](https://getcomposer.org).
 
 ```shell
-php composer.phar require ipinfo/ipinfo
-```
+composer require ipinfo/ipinfo
+``` 
 
 #### Quick Start
 
 ```php
+<?php
+
 require_once __DIR__ . '/vendor/autoload.php';
 
 use ipinfo\ipinfo\IPinfo;


### PR DESCRIPTION
- [x] Add `<?php` into Quickstart to demonstrate that the example must be in its own file
- [x] Remove Composer installation instructions -- aligns with our other SDKs, we do not include installation instructions for their respective package managers
  - [x] Reformat installation command to match standard composer format