### PR TITLE
Fixes PHP8.0 support, add symfony/cache ^7.0 support, phpunit 11,12 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "symfony/http-foundation": "^6.0 || ^6.2 || ^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.0.0 || ^10.0.0",
+        "phpunit/phpunit": "^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0",
         "squizlabs/php_codesniffer": "^3.5.8"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": ">=8.0",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^6.3||^7.0",
-        "symfony/cache": "^6.3",
+        "symfony/cache": "^6.3 || ^7.0",
         "symfony/http-foundation": "^6.2 || ^7.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,11 @@
         "php": ">=8.0",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^6.3||^7.0",
-        "symfony/cache": "^6.3 || ^7.0",
-        "symfony/http-foundation": "^6.2 || ^7.0"
+        "symfony/cache": "^6.0 || ^6.3 || ^7.0",
+        "symfony/http-foundation": "^6.0 || ^6.2 || ^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.0.0",
+        "phpunit/phpunit": "^9.0.0 || ^10.0.0",
         "squizlabs/php_codesniffer": "^3.5.8"
     },
     "autoload": {


### PR DESCRIPTION
This pull request updates dependency version constraints in the `composer.json` file to improve compatibility with a wider range of library versions. 

Fixes #87, fixes #89

Dependency updates:

* Broadened the version constraints for `symfony/cache` to include `^6.0`, ensuring compatibility with older versions alongside the latest ones. (`[composer.jsonL22-R26](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L22-R26)`)
* Broadened the version constraints for `symfony/http-foundation` to include `^6.0`, improving compatibility with older versions. (`[composer.jsonL22-R26](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L22-R26)`)
* Expanded the supported versions of `phpunit/phpunit` to include `^9.0.0`, `^11.0.0`, and `^12.0.0`, allowing for greater flexibility in development environments. (`[composer.jsonL22-R26](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L22-R26)`)