### PR TITLE
Update PHP to 8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The free plan is limited to 50,000 requests per month, and doesn't include some 
 
 #### Installation
 
-The package works with PHP 8 and is available using [Composer](https://getcomposer.org).
+The package works with PHP 8.1 and is available using [Composer](https://getcomposer.org).
 
 ```shell
 composer require ipinfo/ipinfo

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=8.0",
+        "php": ">=8.1",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^6.3||^7.0",
         "symfony/cache": "^6.3",


### PR DESCRIPTION
Currently it's stated that this project works with PHP8+. However, using PHP8 causes error because of the cache dependency #62:

```console
php composer update                                  
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires symfony/cache ^6.3 -> satisfiable by symfony/cache[v6.3.0, ..., v6.4.20].
    - symfony/cache[v6.3.0, ..., v6.4.20] require php >=8.1 -> your php version (8.0.30) does not satisfy that requirement.
```

This pull request updates the PHP version requirement for the project both in README and `composer.json` file.
Fixes #89.

