### PR TITLE
Run tests on PHP 8.3 and 8.4

### DIFF
--- a/.github/workflows/phpunit.yaml
+++ b/.github/workflows/phpunit.yaml
@@ -13,24 +13,29 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['8.0', '8.1', '8.2']        
+        php-versions: ['8.0', '8.1', '8.2', '8.3', '8.4']
         include:
           - php-versions: '8.0'
-            phpunit-versions: '9.5.20'
+            phpunit-versions: 9
           - php-versions: '8.1'
-            phpunit-versions: '10.3.3'
+            phpunit-versions: 10
           - php-versions: '8.2'
-            phpunit-versions: '10.3.3'
-      
-    name: PHP ${{ matrix.php-versions }} Test with PHPUnit ${{ matrix.phpunit-versions }} on ${{ matrix.operating-system }} 
+            phpunit-versions: 10
+          - php-versions: '8.3'
+            phpunit-versions: 11
+          - php-versions: '8.4'
+            phpunit-versions: 12
+
+    name: PHP ${{ matrix.php-versions }} Test with PHPUnit ${{ matrix.phpunit-versions }} on ${{ matrix.operating-system }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Setup PHP with Xdebug
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php-versions }}
+        extensions: json
         tools: phpunit:${{ matrix.phpunit-versions }}
         coverage: xdebug
 


### PR DESCRIPTION
This pull request updates the PHPUnit workflow configuration to support newer PHP and PHPUnit versions, along with minor improvements to the workflow setup.

### PHPUnit workflow updates:
* [`.github/workflows/phpunit.yaml`](diffhunk://#diff-f9f53b313c3981cd079d6912993184a91aafa913954ab46843d2b42d8cf8ee20L16-R38): Added support for PHP versions `8.3` and `8.4` and their corresponding PHPUnit versions `11` and `12`. Updated existing PHPUnit version specifications to use major versions (`9`, `10`) instead of specific patch versions.

### Workflow setup improvements:
* [`.github/workflows/phpunit.yaml`](diffhunk://#diff-f9f53b313c3981cd079d6912993184a91aafa913954ab46843d2b42d8cf8ee20L16-R38): Upgraded the `actions/checkout` action from version `v2` to `v4` for better performance and compatibility.
* [`.github/workflows/phpunit.yaml`](diffhunk://#diff-f9f53b313c3981cd079d6912993184a91aafa913954ab46843d2b42d8cf8ee20L16-R38): Added the `json` extension to the PHP setup step to ensure compatibility with dependencies or tests requiring it.