### PR TITLE
Update Bulgaria currency from BGN to EUR

### DIFF
--- a/src/Const.php
+++ b/src/Const.php
@@ -529,7 +529,7 @@ const CURRENCIES = [
 "BD"  => [ "code" => "BDT" ,"symbol" => "৳"],
 "BE"  => [ "code" => "EUR" ,"symbol" => "€"],
 "BF"  => [ "code" => "XOF" ,"symbol" => "CFA"],
-"BG"  => [ "code" => "BGN" ,"symbol" => "лв"],
+"BG"  => [ "code" => "EUR" ,"symbol" => "€"],
 "BH"  => [ "code" => "BHD" ,"symbol" => ".د.ب"],
 "BI"  => [ "code" => "BIF" ,"symbol" => "FBu"],
 "BJ"  => [ "code" => "XOF" ,"symbol" => "CFA"],

--- a/tests/IPinfoTest.php
+++ b/tests/IPinfoTest.php
@@ -239,9 +239,9 @@ class IPinfoTest extends TestCase
         $this->assertEquals($res->type, 'inactive');
         $this->assertEquals($res->prefixes, []);
         $this->assertEquals($res->prefixes6, []);
-        $this->assertEquals($res->peers, null);
-        $this->assertEquals($res->upstreams, null);
-        $this->assertEquals($res->downstreams, null);
+        $this->assertEquals($res->peers, []);
+        $this->assertEquals($res->upstreams, []);
+        $this->assertEquals($res->downstreams, []);
     }
 
     public function testBogonLocal4()


### PR DESCRIPTION
Bulgaria adopted the Euro starting 1/1/26, this PR changes the country currency code and symbol to reflect that.